### PR TITLE
Fix TODO spellings

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,10 +10,10 @@ from crawl4ai import AsyncWebCrawler, BrowserConfig, CrawlerRunConfig, CacheMode
 import re
 
 # Todo:
-# - pause .act durring question asking, so that the user can answer the question and then continue with the next step.
-# - add Wikipedia search functionallity
-# - add better next_step handeling for example when current step is not correct
-# - add ability for researcher to modefie the research plan, for example to add new steps or remove existing ones
+# - pause .act during question asking, so that the user can answer the question and then continue with the next step.
+# - add Wikipedia search functionality
+# - add better next_step handling for example when current step is not correct
+# - add ability for researcher to modify the research plan, for example to add new steps or remove existing ones
 # - add function to save final report with markdown into /final_report directory with date and time in the filename
 
 


### PR DESCRIPTION
## Summary
- correct typos in the TODO section of `main.py`

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_683f3943e85c832191c5c8fe91390892